### PR TITLE
open the oauth experience in the same tab

### DIFF
--- a/jogger-logger-ui/src/components/app/LoginButton.vue
+++ b/jogger-logger-ui/src/components/app/LoginButton.vue
@@ -8,7 +8,7 @@ if (DEV && !VITE_CLIENT_ID) {
 const callback = encodeURI(`http://${DEV ? 'localhost:5173' : VITE_APP_DOMAIN}/exchange_token`);
 const oauthUrl = `http://www.strava.com/oauth/authorize?client_id=${VITE_CLIENT_ID}&response_type=code&redirect_uri=${callback}&approval_prompt=force&scope=${VITE_OAUTH_SCOPE}`;
 function initOAuth() {
-  window.open(oauthUrl);
+  window.location.href = oauthUrl;
 }
 </script>
 

--- a/jogger-logger-ui/src/views/ActivityView.vue
+++ b/jogger-logger-ui/src/views/ActivityView.vue
@@ -42,7 +42,11 @@ export default {
       <v-container class="ma-0">
         <v-row>
           <template v-for="{ key, label, format } in datum">
-            <ActivityData :label="label" :value="activitiesStore.currentActivity[key]" :format="format" />
+            <ActivityData
+              :label="label"
+              :value="activitiesStore.currentActivity[key]"
+              :format="format"
+            />
           </template>
         </v-row>
       </v-container>


### PR DESCRIPTION
opening the oauth experience in a new tab will result in having two open tabs of the app when the oauth callback returns, one authed and one unauthed.

this change opens the oauth experience in the same tab as login is initiated