### PR TITLE
allow activities to overlap

### DIFF
--- a/jogger-logger-ui/src/components/activities/Activity.vue
+++ b/jogger-logger-ui/src/components/activities/Activity.vue
@@ -1,11 +1,14 @@
 <script lang="ts">
 import type { Activity } from '@/stores/activities/types';
 import type { PropType } from 'vue';
-import { ACTIVITY_HEIGHT, MAX_METER_SCALAR, MIN_ACTIVITY_DISPLAY_SIZE } from './constants';
+import { MAX_ACTIVITY_RADIUS, MAX_METER_SCALAR, MIN_ACTIVITY_RADIUS } from './constants';
 import { useActivitiesStore } from '@/stores/activities';
 
+const MIN_ACTIVITY_DIAMETER = MIN_ACTIVITY_RADIUS * 2;
+const MAX_ACTIVITY_DIAMETER = MAX_ACTIVITY_RADIUS * 2;
+
 export default {
-  props: { activity: Object as PropType<Activity> },
+  props: { activity: Object as PropType<Activity>, topOffset: String },
 
   setup() {
     const activitiesStore = useActivitiesStore();
@@ -18,11 +21,12 @@ export default {
         ? Math.min(this.activity.distance, MAX_METER_SCALAR) / MAX_METER_SCALAR
         : 0;
       const activityDisplaySize =
-        MIN_ACTIVITY_DISPLAY_SIZE + (ACTIVITY_HEIGHT - MIN_ACTIVITY_DISPLAY_SIZE) * distanceScalar;
+        MIN_ACTIVITY_DIAMETER + (MAX_ACTIVITY_DIAMETER - MIN_ACTIVITY_DIAMETER) * distanceScalar;
       const sizePixels = `${activityDisplaySize}px`;
       return {
         height: sizePixels,
         width: sizePixels,
+        top: this.topOffset,
       };
     },
   },
@@ -43,7 +47,7 @@ export default {
     <template v-slot:default="{ isHovering, props }">
       <v-card
         :style="activityStyle"
-        class="ma-2 activity"
+        class="mx-auto activity"
         v-bind="props"
         :color="isHovering ? 'secondary' : 'primary'"
         @click="setCurrentActivity"
@@ -55,5 +59,7 @@ export default {
 <style scoped>
 .activity {
   clip-path: circle();
+  position: absolute;
+  opacity: 0.5;
 }
 </style>

--- a/jogger-logger-ui/src/components/activities/TrainingDay.vue
+++ b/jogger-logger-ui/src/components/activities/TrainingDay.vue
@@ -2,17 +2,24 @@
 import { TrainingDay } from '@/stores/activities/getActivitiesByWeek';
 import Activity from './Activity.vue';
 import TrainingDayPopover from './TrainingDayPopover.vue';
+import { TRAINING_WEEK_HEIGHT, MAX_ACTIVITY_RADIUS } from './constants';
 
 export default {
   props: { trainingDay: TrainingDay },
   components: { Activity, TrainingDayPopover },
+  setup(props) {
+    const numberOfActivities = props.trainingDay?.activities.length || 1;
+    const spaceBetweenActivities =
+      (TRAINING_WEEK_HEIGHT - MAX_ACTIVITY_RADIUS) / (numberOfActivities + 1);
+    return { spaceBetweenActivities };
+  },
 };
 </script>
 
 <template>
-  <v-col class="ma-auto d-flex flex-column align-center" v-if="trainingDay">
-    <template v-for="activity in trainingDay.activities">
-      <Activity :activity="activity" />
+  <v-col class="h-100 d-flex justify-center" style="position: relative" v-if="trainingDay">
+    <template v-for="(activity, index) in trainingDay.activities">
+      <Activity :activity="activity" :topOffset="`${(index + 1) * spaceBetweenActivities}px`" />
     </template>
     <TrainingDayPopover :trainingDay="trainingDay" />
   </v-col>

--- a/jogger-logger-ui/src/components/activities/TrainingLog.vue
+++ b/jogger-logger-ui/src/components/activities/TrainingLog.vue
@@ -3,16 +3,16 @@ import { useActivitiesStore } from '@/stores/activities';
 import { getActivitiesByWeek } from '@/stores/activities/getActivitiesByWeek';
 import { debounce } from '@/utils/debounce';
 import TrainingWeek from './TrainingWeek.vue';
-import { ACTIVITY_HEIGHT } from './constants';
+import { TRAINING_WEEK_HEIGHT } from './constants';
 import DebouncedVirtualScroll from './DebouncedVirtualScroll.vue';
 
 const APP_BAR_HEIGHT = 64;
-const LOADING_BUFFER = ACTIVITY_HEIGHT;
+const LOADING_BUFFER = TRAINING_WEEK_HEIGHT;
 
 export default {
   setup() {
     return {
-      itemHeight: ACTIVITY_HEIGHT,
+      itemHeight: TRAINING_WEEK_HEIGHT,
       debounce,
     };
   },

--- a/jogger-logger-ui/src/components/activities/TrainingWeek.vue
+++ b/jogger-logger-ui/src/components/activities/TrainingWeek.vue
@@ -2,12 +2,12 @@
 import { TrainingWeek } from '@/stores/activities/getActivitiesByWeek';
 import { WEEKDAYS, dateToLocaleDateString } from '@/utils/dates';
 import TrainingDay from './TrainingDay.vue';
-import { ACTIVITY_HEIGHT } from './constants';
+import { TRAINING_WEEK_HEIGHT } from './constants';
 
 export default {
   props: { trainingWeek: TrainingWeek },
   setup() {
-    return { WEEKDAYS, style: `height: ${ACTIVITY_HEIGHT}px` };
+    return { WEEKDAYS, style: `height: ${TRAINING_WEEK_HEIGHT}px` };
   },
   components: { TrainingDay },
   methods: { dateToLocaleDateString },

--- a/jogger-logger-ui/src/components/activities/constants.ts
+++ b/jogger-logger-ui/src/components/activities/constants.ts
@@ -1,3 +1,4 @@
-export const ACTIVITY_HEIGHT = 200;
+export const TRAINING_WEEK_HEIGHT = 200;
+export const MAX_ACTIVITY_RADIUS = 50;
+export const MIN_ACTIVITY_RADIUS = 15;
 export const MAX_METER_SCALAR = 1600 * 50; // 1600 m/mi * 50 mi
-export const MIN_ACTIVITY_DISPLAY_SIZE = 50;


### PR DESCRIPTION
on activity screen, display the activities with some overlap without going over the week boundaries

<img width="1512" alt="Screenshot 2023-06-25 at 10 16 43 AM" src="https://github.com/lemartin19/jogger-logger/assets/30056088/1f1ae2bd-6c23-4972-ab8e-055ff11b5197">
